### PR TITLE
fix: 安装 amoro 提示找不到文件 FileNotFoundException

### DIFF
--- a/cloudeon-server/src/main/java/org/dromara/cloudeon/processor/InitAmoroDBTask.java
+++ b/cloudeon-server/src/main/java/org/dromara/cloudeon/processor/InitAmoroDBTask.java
@@ -53,7 +53,7 @@ public class InitAmoroDBTask  extends BaseCloudeonTask  {
         String url = configRepository.findByServiceInstanceIdAndName(serviceInstanceId, "ams.mysql.ConnectionURL").getValue();
         DataSource ds = new SimpleDataSource(url, username, password);
 
-        String sqlPath = stackLoadPath+ File.separator+ stackServiceEntity.getStackCode() + File.separator + stackServiceEntity.getName() + File.separator + Constant.StackPackageRenderDir + File.separator+ "mysql"+ File.separator+ "ams-mysql-init.sql";
+        String sqlPath = stackLoadPath+ File.separator+ stackServiceEntity.getStackCode() + File.separator + stackServiceEntity.getName().toLowerCase() + File.separator + Constant.StackPackageRenderDir + File.separator+ "mysql"+ File.separator+ "ams-mysql-init.sql";
         try (Connection conn = ds.getConnection()) {
             FileInputStream sqlFileStream = new FileInputStream(sqlPath);
             ScriptRunner initScriptRunner = new ScriptRunner(conn, true, true,log);


### PR DESCRIPTION
fix: 安装 amoro 提示找不到文件 FileNotFoundException 

/usr/local/cloudeon/cloudeon-assembly/stack/EDP-1.0.0/AMORO/render/mysql/ams-mysql-init.sql     修改为/usr/local/cloudeon/cloudeon-assembly/stack/EDP-1.0.0/amoro/render/mysql/ams-mysql-init.sql